### PR TITLE
Forcefield mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ eggs/
 # IntelliJ files
 .idea
 mdfts.iml
+
+# custom files
+_t* #temporary test files

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ mdfts.iml
 
 # custom files
 _t* 
+site/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ eggs/
 # IntelliJ files
 .idea
 mdfts.iml
+
+# custom files
+_t* 
+site/

--- a/src/mdfts/utils/serial.py
+++ b/src/mdfts/utils/serial.py
@@ -97,7 +97,7 @@ class Serializable(object):
             can also support list, but that is not preferable since it relies on knowing
             the sequence of tracked variables in the class.
         """
-        print(self)
+        #print(self)
         if isinstance(d, collectionsABC.Mapping):  # dictlike
             for (k, v) in d.items():
                 if k in self._serial_vars:
@@ -228,18 +228,22 @@ def serialize(track_args):
                 self.__class__.__module__ = cls.__module__
 
             def __str__(self):  # pretier reporting to get around manual decorator
-                return "<{}.{} object at {}>".format(
-                    self.__class__.__module__, self.__class__.__name__, hex(id(self))
-                )
+                #ret = "<{}.{} object at {}>\n".format(
+                #    self.__class__.__module__, self.__class__.__name__, hex(id(self))
+                #)
+                #ret += "\n{}".format(cls.__str__(self))
+                ret = "<{}> {}".format(self.__class__.__name__,cls.__str__(self))
+                return ret
 
             def __repr__(self):  # pretier reporting to get around manual decorator
-                return "<{}.{}-wrapped {}.{} object at {}>".format(
+                ret =  "<{}.{}-wrapped {}.{} object at {}>".format(
                     serialize.__module__,
                     serialize.__name__,
                     self.__class__.__module__,
                     self.__class__.__name__,
                     hex(id(self)),
                 )
+                return ret
 
         return myclass
 

--- a/src/tests/test_forcefield_serialization.py
+++ b/src/tests/test_forcefield_serialization.py
@@ -1,0 +1,20 @@
+import mdfts.forcefield.forcefield as ff
+
+
+print('=== sample force field')
+f = ff.ForceField()
+f.add_bead_type( ff.BeadType('A',2.0,-1.0) )
+f.add_bead_type( ff.BeadType('B',5.0,1.0) )
+fdict = f.to_dict()
+print(f)
+
+print("\nserializes to:\n{}".format(fdict))
+
+
+print("\n=== Make another forcefield from the above")
+g = ff.ForceField()
+g.from_dict(fdict)
+gdict = g.to_dict()
+print(g)
+print("\nserializes to:\n{}".format(gdict))
+


### PR DESCRIPTION
Added custom handling for serializing `_bead_types` and `_potentials`, which are of type `list` instead of `Serializable`.
Also, more informative prints for `ForceField` and `BeadType`, and added very light check.

Should probably turn the `/src/tests/test_forcefield_serialization.py` into a proper unit test.